### PR TITLE
Improve home button accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <div class="pill">
       <span>🔥</span> <span id="streakText"></span>
     </div>
-    <button class="ghost" id="homeBtn" title="Forside / Home">🏠</button>
+    <button class="ghost" id="homeBtn" aria-label="Forside"><span class="sr-only">Forside</span>🏠</button>
     <select id="langSelect" class="ghost">
       <option value="da">Dansk</option>
       <option value="en">English</option>

--- a/render.js
+++ b/render.js
@@ -4,6 +4,10 @@ export function renderTexts(state, t) {
   document.getElementById("modulesTitle").textContent = t("modules");
   document.getElementById("streakText").textContent = t("streak") + " " + (state.streak.count || 0);
   document.getElementById("footerText").textContent = t("footer").replace("YEAR", new Date().getFullYear());
+  const homeBtn = document.getElementById("homeBtn");
+  homeBtn.setAttribute("aria-label", t("home"));
+  const sr = homeBtn.querySelector(".sr-only");
+  if (sr) sr.textContent = t("home");
   document.getElementById("langSelect").value = state.lang;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,17 @@
     --card:#111827; --chip:#1f2937; --border:#1f2937; --shadow:0 10px 30px rgba(0,0,0,.35); --radius:14px;
   }
   *{box-sizing:border-box}
+  .sr-only{
+    position:absolute;
+    width:1px;
+    height:1px;
+    padding:0;
+    margin:-1px;
+    overflow:hidden;
+    clip:rect(0,0,0,0);
+    white-space:nowrap;
+    border:0;
+  }
   html,body{height:100%}
   body{
     margin:0; font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,'Helvetica Neue',Arial;


### PR DESCRIPTION
## Summary
- Add localized `aria-label` and screen-reader text for the home button
- Update text rendering to localize the home button label
- Define reusable `.sr-only` style for hidden accessibility text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada6c1b4c8832aa02a32875dcb7ee3