### PR TITLE
Add data management section with export and reset controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 import { Store } from './storage.js';
-import { renderTexts, renderSidebar, renderHome } from './render.js';
+import { renderTexts, renderSidebar, renderHome, renderData } from './render.js';
 
 const Lang = {
   en: {
@@ -22,6 +22,12 @@ const Lang = {
     pagesDone: "Pages completed",
     latestBadge: "Latest badge",
     footer: "© YEAR Diabetes Distress iCBT • Private by design (data stored only in your browser).",
+    data: "Data",
+    dataTitle: "Data & Privacy",
+    dataInfo: "All progress is stored only in this browser. You can download it or clear it.",
+    downloadData: "Download data",
+    clearData: "Clear all data",
+    confirmClear: "This will erase all data. Continue?",
     /* NEW */
     progressTitle: "Your Progress",
     badgesTitle: "Badges",
@@ -97,6 +103,12 @@ const Lang = {
     pagesDone: "Sider færdiggjort",
     latestBadge: "Seneste mærke",
     footer: "© YEAR Diabetes-stress iCBT • Gemmes kun i din browser.",
+    data: "Data",
+    dataTitle: "Data & privatliv",
+    dataInfo: "Alle fremskridt gemmes lokalt i denne browser. Du kan downloade eller slette dem.",
+    downloadData: "Download data",
+    clearData: "Slet alle data",
+    confirmClear: "Er du sikker på, at du vil slette alle data? Dette kan ikke fortrydes.",
     /* NEW */
     progressTitle: "Dit fremskridt",
     badgesTitle: "Mærker",
@@ -224,6 +236,34 @@ function overallProgress(s){
 }
 function navigateTo(mi, pi) { location.hash = `#/m/${mi}/p/${pi}`; }
 function onRoute(){
+  if (location.hash === "#data") {
+    renderSidebar(state, Lang, navigateTo);
+    renderData(state, t);
+    const dl = document.getElementById("downloadBtn");
+    if (dl) dl.onclick = () => {
+      Store.save(state);
+      const dataStr = JSON.stringify(state, null, 2);
+      const blob = new Blob([dataStr], {type:"application/json"});
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "dd-data.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    };
+    const cl = document.getElementById("clearBtn");
+    if (cl) cl.onclick = () => {
+      if (confirm(t("confirmClear"))) {
+        localStorage.removeItem(Store.key);
+        state = Store.load();
+        location.hash = "";
+        renderTexts(state, t);
+        renderSidebar(state, Lang, navigateTo);
+        renderHome(state, t, overallProgress);
+      }
+    };
+    return;
+  }
   const m = location.hash.match(/#\/m\/(\d+)\/p\/(\d+)/);
   if(!m){
     renderHome(state, t, overallProgress);
@@ -669,6 +709,10 @@ function init() {
   document.getElementById("homeBtn").onclick = () => {
     location.hash = "";
     renderHome(state, t, overallProgress);
+  };
+
+  document.getElementById("dataBtn").onclick = () => {
+    location.hash = "#data";
   };
 
   window.addEventListener("hashchange", onRoute);

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <span>🔥</span> <span id="streakText"></span>
     </div>
     <button class="ghost" id="homeBtn" aria-label="Forside"><span class="sr-only">Forside</span>🏠</button>
+    <button class="ghost" id="dataBtn" aria-label="Data"><span class="sr-only">Data</span>💾</button>
     <select id="langSelect" class="ghost">
       <option value="da">Dansk</option>
       <option value="en">English</option>

--- a/render.js
+++ b/render.js
@@ -8,6 +8,12 @@ export function renderTexts(state, t) {
   homeBtn.setAttribute("aria-label", t("home"));
   const sr = homeBtn.querySelector(".sr-only");
   if (sr) sr.textContent = t("home");
+  const dataBtn = document.getElementById("dataBtn");
+  if (dataBtn) {
+    dataBtn.setAttribute("aria-label", t("data"));
+    const sr2 = dataBtn.querySelector(".sr-only");
+    if (sr2) sr2.textContent = t("data");
+  }
   document.getElementById("langSelect").value = state.lang;
 }
 
@@ -58,5 +64,20 @@ export function renderHome(state, t, overallProgress) {
         + '<article class="flow"><h2>' + t("badgesTitle") + '</h2><div class="badgebar" id="badgeBar">' + badges + '</div></article>'
         + '<article class="flow"><h2>' + t("activityTitle") + '</h2><div class="timeline" id="timeline">' + recent + '</div></article>'
       + '</section>'
+    + '</div>';
+}
+export function renderData(state, t) {
+  const main = document.getElementById("main");
+  main.innerHTML = ''
+    + '<div class="page">'
+    +   '<div class="hero"><h1>' + t("dataTitle") + '</h1></div>'
+    +   '<section class="content flow">'
+    +     '<p>' + t("dataInfo") + '</p>'
+    +     '<div class="cta-row">'
+    +       '<button id="downloadBtn">' + t("downloadData") + '</button>'
+    +       '<div class="spacer"></div>'
+    +       '<button class="ghost" id="clearBtn">' + t("clearData") + '</button>'
+    +     '</div>'
+    +   '</section>'
     + '</div>';
 }


### PR DESCRIPTION
## Summary
- Add Data button in header linking to new data management view
- Enable downloading stored state as JSON
- Add option to clear all saved data with confirmation and privacy note

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ada7d6600c832ab817883005030613