### PR TITLE
Trigger data route immediately

### DIFF
--- a/app.js
+++ b/app.js
@@ -713,6 +713,7 @@ function init() {
 
   document.getElementById("dataBtn").onclick = () => {
     location.hash = "#data";
+    onRoute(); // trigger rendering immediately
   };
 
   window.addEventListener("hashchange", onRoute);


### PR DESCRIPTION
## Summary
- Ensure clicking the **Data** sidebar button navigates to the data management view immediately by invoking `onRoute()` after setting the hash.

## Testing
- `node - <<'NODE'
let called=false;
function onRoute(){ called=true; }
let location={ hash:'' };
(() => { location.hash = '#data'; onRoute(); })();
console.log('hash:', location.hash, 'onRouteCalled:', called);
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adaafe6c78832aa55f301740cb1c0b