### PR TITLE
Implement responsive off-canvas sidebar drawer

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,6 +179,55 @@ function toast(msg){ let d=document.createElement("div"); d.textContent=msg;
 }
 function clamp(n,min,max){ return Math.max(min, Math.min(max, n)); }
 
+function initDrawer(){
+  const drawer = document.getElementById("drawer");
+  const overlay = document.getElementById("drawerOverlay");
+  const menuBtn = document.getElementById("menuBtn");
+  if(!drawer || !overlay || !menuBtn) return;
+
+  function trapFocus(e){
+    if(e.key !== "Tab") return;
+    const focusable = drawer.querySelectorAll('a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])');
+    if(focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if(e.shiftKey && document.activeElement === first){ e.preventDefault(); last.focus(); }
+    else if(!e.shiftKey && document.activeElement === last){ e.preventDefault(); first.focus(); }
+  }
+
+  function open(){
+    drawer.classList.add("open");
+    overlay.classList.add("show");
+    overlay.removeAttribute("hidden");
+    menuBtn.setAttribute("aria-expanded","true");
+    document.body.style.overflow = "hidden";
+    const focusable = drawer.querySelectorAll('a, button, input, textarea, select, [tabindex]:not([tabindex="-1"])');
+    (focusable[0] || drawer).focus();
+    drawer.addEventListener("keydown", trapFocus);
+  }
+
+  function close(){
+    drawer.classList.remove("open");
+    overlay.classList.remove("show");
+    overlay.setAttribute("hidden","");
+    menuBtn.setAttribute("aria-expanded","false");
+    document.body.style.overflow = "";
+    drawer.removeEventListener("keydown", trapFocus);
+    menuBtn.focus();
+  }
+
+  menuBtn.addEventListener("click", () => {
+    if(drawer.classList.contains("open")) close(); else open();
+  });
+  overlay.addEventListener("click", close);
+  document.addEventListener("keydown", e => {
+    if(e.key === "Escape" && drawer.classList.contains("open")) close();
+  });
+  window.addEventListener("resize", () => {
+    if(window.innerWidth >= 768) close();
+  });
+}
+
 /* Exercise locale strings */
 const EX={
   en:{add:"Add",save:"Save",delete:"Delete",done:"Done",edit:"Edit",
@@ -701,6 +750,7 @@ function renderExercise(root, page){
 
 /* ========== Language Switcher & Init ========== */
 function init() {
+  initDrawer();
   document.getElementById("langSelect").onchange = e => {
     state.lang = e.target.value;
     Store.save(state);

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 <body>
 <header>
   <div class="wrap topbar">
+    <button class="ghost" id="menuBtn" aria-label="Menu"><span class="sr-only">Menu</span>☰</button>
     <div class="brand">
       <div class="logo"></div>
       <div>
@@ -32,11 +33,15 @@
   </div>
 </header>
 
+<div id="drawerOverlay" class="overlay" hidden></div>
+
 <div class="wrap layout">
-  <aside class="card sidebar">
-    <h2 id="modulesTitle"></h2>
-    <div id="moduleList"></div>
-  </aside>
+  <div id="drawer" class="drawer">
+    <aside class="card sidebar">
+      <h2 id="modulesTitle"></h2>
+      <div id="moduleList"></div>
+    </aside>
+  </div>
 
   <main class="card" id="main" role="main">
     <!-- Home / module pages are injected here -->

--- a/styles.css
+++ b/styles.css
@@ -33,8 +33,11 @@
   .spacer{flex:1}
   .pill{display:inline-flex; align-items:center; gap:10px; padding:8px 12px; border-radius:999px;
     background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)); border:1px solid var(--border); color:var(--muted); font-size:.9rem;}
+  #menuBtn{display:none}
   .layout{display:grid; grid-template-columns:280px 1fr; gap:18px; padding:18px}
-  aside{position:sticky; top:72px; height:calc(100dvh - 90px); overflow:auto; padding-right:8px}
+  .drawer{width:280px}
+  .drawer .sidebar{position:sticky; top:72px; height:calc(100dvh - 90px); overflow:auto; padding-right:8px}
+  .overlay{display:none}
   .card{background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,0)); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow);}
   .sidebar .mod{padding:12px 14px; border-bottom:1px dashed rgba(148,163,184,.2); display:grid; grid-template-columns: 1fr auto; gap:8px; align-items:center; cursor:pointer;}
   .sidebar .mod:hover{background:rgba(255,255,255,.03)}
@@ -85,7 +88,27 @@
   .breath{width:180px;height:180px;border-radius:50%;margin:10px auto;background:radial-gradient(circle at 50% 50%, rgba(34,197,94,.35), rgba(34,197,94,0)); border:2px solid #1e3a2f; animation: breathe 8s ease-in-out infinite; box-shadow: inset 0 0 40px rgba(34,197,94,.3)}
   @keyframes breathe{0%{transform:scale(0.8)}50%{transform:scale(1)}100%{transform:scale(0.8)}}
   footer{color:#8aa0be; font-size:.9rem; padding:18px; border-top:1px solid var(--border)}
-  @media (max-width: 900px){ .layout{grid-template-columns:1fr} aside{position:relative; height:auto} .kpi{grid-template-columns: 1fr;} }
+  @media (max-width: 900px){ .kpi{grid-template-columns: 1fr;} }
+
+  @media (max-width: 768px){
+    #menuBtn{display:inline-block}
+    .layout{display:block}
+    .drawer{
+      position:fixed; top:0; left:0; bottom:0; width:280px; max-width:80%;
+      transform:translateX(-100%); transition:transform .3s ease; z-index:101;
+    }
+    .drawer.open{transform:translateX(0)}
+    .drawer .sidebar{position:relative; top:0; height:100%; overflow:auto; padding-right:8px}
+    .overlay{
+      display:block; position:fixed; inset:0; background:rgba(0,0,0,.6);
+      opacity:0; pointer-events:none; transition:opacity .3s; z-index:100;
+    }
+    .overlay.show{opacity:1; pointer-events:auto}
+  }
+
+  @media (min-width: 769px){
+    .overlay{display:none}
+  }
 
   /* Mini progress in page header (animations optional later) */
   .mini-progress{display:flex; align-items:center; gap:10px; margin-top:10px;}


### PR DESCRIPTION
## Summary
- Add header menu button and overlay-wrapped drawer container for sidebar
- Convert fixed sidebar into responsive off-canvas drawer with sliding animation
- Provide JavaScript to toggle drawer with focus trapping and escape/overlay close support

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbad8ac60832a92b614157d77dbf1