### PR TITLE
feat: add responsive topbar dropdown

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,6 +228,31 @@ function initDrawer(){
   });
 }
 
+function initTopbarMenu(){
+  const moreBtn = document.getElementById("moreBtn");
+  const actions = document.getElementById("topbarActions");
+  if(!moreBtn || !actions) return;
+
+  moreBtn.addEventListener("click", () => {
+    const open = actions.classList.toggle("open");
+    moreBtn.setAttribute("aria-expanded", open ? "true" : "false");
+  });
+
+  document.addEventListener("click", e => {
+    if(!actions.contains(e.target) && !moreBtn.contains(e.target)){
+      actions.classList.remove("open");
+      moreBtn.setAttribute("aria-expanded","false");
+    }
+  });
+
+  window.addEventListener("resize", () => {
+    if(window.innerWidth >= 600){
+      actions.classList.remove("open");
+      moreBtn.setAttribute("aria-expanded","false");
+    }
+  });
+}
+
 /* Exercise locale strings */
 const EX={
   en:{add:"Add",save:"Save",delete:"Delete",done:"Done",edit:"Edit",
@@ -751,6 +776,7 @@ function renderExercise(root, page){
 /* ========== Language Switcher & Init ========== */
 function init() {
   initDrawer();
+  initTopbarMenu();
   document.getElementById("langSelect").onchange = e => {
     state.lang = e.target.value;
     Store.save(state);

--- a/index.html
+++ b/index.html
@@ -21,15 +21,18 @@
       </div>
     </div>
     <div class="spacer"></div>
-    <div class="pill">
-      <span>🔥</span> <span id="streakText"></span>
+    <div class="actions" id="topbarActions">
+      <div class="pill">
+        <span>🔥</span> <span id="streakText"></span>
+      </div>
+      <button class="ghost" id="homeBtn" aria-label="Forside"><span class="sr-only">Forside</span>🏠</button>
+      <button class="ghost" id="dataBtn" aria-label="Data"><span class="sr-only">Data</span>💾</button>
+      <select id="langSelect" class="ghost">
+        <option value="da">Dansk</option>
+        <option value="en">English</option>
+      </select>
     </div>
-    <button class="ghost" id="homeBtn" aria-label="Forside"><span class="sr-only">Forside</span>🏠</button>
-    <button class="ghost" id="dataBtn" aria-label="Data"><span class="sr-only">Data</span>💾</button>
-    <select id="langSelect" class="ghost">
-      <option value="da">Dansk</option>
-      <option value="en">English</option>
-    </select>
+    <button class="ghost" id="moreBtn" aria-label="Menu" aria-haspopup="true" aria-expanded="false"><span class="sr-only">Menu</span>☰</button>
   </div>
 </header>
 

--- a/styles.css
+++ b/styles.css
@@ -31,9 +31,11 @@
   .brand{display:flex; align-items:center; gap:10px; font-weight:800; letter-spacing:.3px}
   .brand .logo{width:34px;height:34px;border-radius:10px;background:conic-gradient(from 210deg,#22c55e,#38bdf8,#22c55e); box-shadow:0 0 0 3px rgba(56,189,248,.2), inset 0 0 16px rgba(0,0,0,.4);}
   .spacer{flex:1}
+  .actions{display:flex; align-items:center; gap:14px}
   .pill{display:inline-flex; align-items:center; gap:10px; padding:8px 12px; border-radius:999px;
     background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,0)); border:1px solid var(--border); color:var(--muted); font-size:.9rem;}
   #menuBtn{display:none}
+  #moreBtn{display:none}
   .layout{display:grid; grid-template-columns:280px 1fr; gap:18px; padding:18px}
   .drawer{width:280px}
   .drawer .sidebar{position:sticky; top:72px; height:calc(100dvh - 90px); overflow:auto; padding-right:8px}
@@ -89,6 +91,16 @@
   @keyframes breathe{0%{transform:scale(0.8)}50%{transform:scale(1)}100%{transform:scale(0.8)}}
   footer{color:#8aa0be; font-size:.9rem; padding:18px; border-top:1px solid var(--border)}
   @media (max-width: 900px){ .kpi{grid-template-columns: 1fr;} }
+
+  @media (max-width: 600px){
+    .topbar{position:relative}
+    #moreBtn{display:inline-block}
+    .actions{display:none; position:absolute; top:100%; right:0; background:var(--panel);
+      flex-direction:column; gap:8px; padding:10px; border:1px solid var(--border);
+      border-radius:8px; box-shadow:var(--shadow); z-index:200;}
+    .actions.open{display:flex}
+    .actions .pill{justify-content:center; width:100%}
+  }
 
   @media (max-width: 768px){
     #menuBtn{display:inline-block}


### PR DESCRIPTION
## Summary
- Convert topbar actions into flex container with dropdown on narrow screens
- Hide streak and navigation controls behind hamburger menu at small widths
- Add responsive media queries and JS toggle for dropdown

## Testing
- `node --check app.js render.js storage.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb2348708832abaed22a609d1aad1