### PR TITLE
Prevent topbar menu from closing immediately

### DIFF
--- a/app.js
+++ b/app.js
@@ -233,7 +233,8 @@ function initTopbarMenu(){
   const actions = document.getElementById("topbarActions");
   if(!moreBtn || !actions) return;
 
-  moreBtn.addEventListener("click", () => {
+  moreBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
     const open = actions.classList.toggle("open");
     moreBtn.setAttribute("aria-expanded", open ? "true" : "false");
   });


### PR DESCRIPTION
## Summary
- stop click events on the topbar "more" button from bubbling so the document listener doesn't instantly close the menu

## Testing
- `node - <<'NODE'...` (custom DOM simulation verifying menu toggles)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb5b8ab14832a96952207d9420efd