### PR TITLE
Ensure mobile drawer sidebar is opaque

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -118,7 +118,12 @@ footer{color:#8aa0be; font-size:.9rem; padding:1.125rem; border-top:1px solid va
     transform:translateX(-100%); transition:transform .3s ease; z-index:101;
   }
   .drawer.open{transform:translateX(0)}
-  .drawer .sidebar{position:relative; top:0; height:100%; overflow:auto; padding-right:0.5rem}
+  .drawer .sidebar{
+    position:relative; top:0; height:100%; overflow:auto; padding-right:0.5rem;
+    background:var(--panel);
+    box-shadow:var(--shadow);
+    border-right:1px solid var(--border);
+  }
   .overlay{
     display:block; position:fixed; inset:0; background:rgba(0,0,0,.6);
     opacity:0; pointer-events:none; transition:opacity .3s; z-index:100;


### PR DESCRIPTION
## Summary
- Override mobile drawer sidebar background with panel color to remove gradient
- Add box shadow and border to distinguish sidebar from overlay

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aeba549b14832ab85602919d167883