### PR TITLE
Render all badges with locked styling

### DIFF
--- a/render.js
+++ b/render.js
@@ -36,9 +36,19 @@ export function renderHome(state, t, overallProgress) {
   const pctNum = Math.round(overallProgress(state) * 100);
   const pages = Object.keys(state.completed).length;
 
-  const badges = state.badges && state.badges.length
-    ? state.badges.map(b => '<span class="chip">🏅 ' + b + '</span>').join('')
-    : '<span class="tiny">' + (state.lang === "da" ? "Ingen mærker endnu — de vises her, når du låser dem op." : "No badges yet — they’ll appear here as you unlock them.") + '</span>';
+  const ALL_BADGES = [
+    'Getting Started',
+    'Quarter Way',
+    'Halfway Hero',
+    'Almost There',
+    'Completed 🎉'
+  ];
+  const unlocked = new Set(state.badges || []);
+  const badges = ALL_BADGES.map(b =>
+    unlocked.has(b)
+      ? '<span class="chip">🏅 ' + b + '</span>'
+      : '<span class="chip locked">' + b + '</span>'
+  ).join('');
 
   const recent = state.timeline && state.timeline.length
     ? state.timeline.slice(-6).reverse().map(ev => {
@@ -55,7 +65,7 @@ export function renderHome(state, t, overallProgress) {
         + '<div class="kpi">'
           + '<div class="tile"><div class="big">' + pctNum + '%</div><div class="tiny">' + t("overall") + '</div></div>'
           + '<div class="tile"><div class="big">' + pages + '</div><div class="tiny">' + t("pagesDone") + '</div></div>'
-          + '<div class="tile"><div class="big">' + (state.badges.slice(-1)[0] || t("none")) + '</div><div class="tiny">' + t("latestBadge") + '</div></div>'
+          + '<div class="tile"><div class="big">' + ((state.badges && state.badges.slice(-1)[0]) || t("none")) + '</div><div class="tiny">' + t("latestBadge") + '</div></div>'
         + '</div>'
         + '<div class="row" style="align-items:center">'
           + '<div class="progress-ring" style="--p:' + pctNum + '%"><b>' + pctNum + '%</b></div>'

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,7 @@ button.ghost{background:transparent; border:1px dashed var(--border)} button:dis
 .tile .big{font-size:clamp(1.4rem,4vw,1.8rem); font-weight:800}
 .badgebar{display:flex; gap:0.5rem; flex-wrap:wrap}
 .chip{background:var(--chip); border:1px solid var(--border); padding:0.375rem 0.625rem; border-radius:999px; font-size:.85rem}
+.chip.locked{opacity:0.4; filter:grayscale(1)}
 .flow{display:grid; gap:0.875rem}
 .checklist label{display:flex; gap:0.625rem; align-items:flex-start; padding:0.5rem; border:1px solid var(--border); border-radius:0.625rem}
 input[type="checkbox"]{width:1.125rem;height:1.125rem}


### PR DESCRIPTION
## Summary
- Always render all five progression badges and show locked ones in gray
- Prevent latest badge tile crash when no badges earned yet
- Style `.chip.locked` to visually dim unavailable badges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aecf6a0d04832a968d3899ba080ee9