### PR TITLE
refactor: centralize badge definitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,14 @@
 import { Store } from './storage.js';
 import { renderTexts, renderSidebar, renderHome, renderData } from './render.js';
 
+export const BADGES = [
+  { th: 0.01, n: "Getting Started" },
+  { th: 0.25, n: "Quarter Way" },
+  { th: 0.5, n: "Halfway Hero" },
+  { th: 0.75, n: "Almost There" },
+  { th: 0.99, n: "Completed 🎉" }
+];
+
 const Lang = {
   en: {
     brandTitle: "Diabetes Distress iCBT",
@@ -319,9 +327,12 @@ function bumpStreak(){
 }
 function awardBadges(){
   let p=overallProgress(state);
-  let set=[{th:.01,n:"Getting Started"},{th:.25,n:"Quarter Way"},{th:.5,n:"Halfway Hero"},{th:.75,n:"Almost There"},{th:.99,n:"Completed 🎉"}];
-  for(let i=0;i<set.length;i++){
-    let b=set[i]; if(p>=b.th && state.badges.indexOf(b.n)===-1){ state.badges.push(b.n); state.timeline.push({t:now(),what:"Badge: "+b.n}); }
+  for(let i=0;i<BADGES.length;i++){
+    let b=BADGES[i];
+    if(p>=b.th && state.badges.indexOf(b.n)===-1){
+      state.badges.push(b.n);
+      state.timeline.push({t:now(),what:"Badge: "+b.n});
+    }
   }
   Store.save(state);
 }

--- a/render.js
+++ b/render.js
@@ -1,3 +1,5 @@
+import { BADGES } from './app.js';
+
 export function renderTexts(state, t) {
   document.getElementById("brandTitle").textContent = t("brandTitle");
   document.getElementById("brandSubtitle").textContent = t("brandSubtitle");
@@ -36,17 +38,11 @@ export function renderHome(state, t, overallProgress) {
   const pctNum = Math.round(overallProgress(state) * 100);
   const pages = Object.keys(state.completed).length;
 
-  const ALL_BADGES = [
-    'Getting Started',
-    'Quarter Way',
-    'Halfway Hero',
-    'Almost There',
-    'Completed 🎉'
-  ];
   const unlocked = new Set(state.badges || []);
-  const badges = ALL_BADGES.map(b => {
-    const isUnlocked = unlocked.has(b);
-    const label = isUnlocked ? '🏅&nbsp;' + b : b;
+  const badges = BADGES.map(b => {
+    const name = b.n;
+    const isUnlocked = unlocked.has(name);
+    const label = isUnlocked ? '🏅&nbsp;' + name : name;
     const cls = isUnlocked ? 'chip' : 'chip locked';
     return '<span class="' + cls + '">' + label + '</span>';
   }).join('');


### PR DESCRIPTION
## Summary
- export a single badge definition list from app.js
- use shared badge list in awardBadges() and renderHome()

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed39b5f8c832aa6e2b8a0e300c486