### PR TITLE
Add language-specific encouragement toast

### DIFF
--- a/app.js
+++ b/app.js
@@ -441,6 +441,11 @@ function openPage(mi,pi){
     state.timeline.push({t:now(), what:"Completed "+page.title});
     bumpStreak(); awardBadges(); Store.save(state);
     toast(EX[state.lang].completed);
+    if(state.lang === 'da'){
+      toast("Godt gået! Små skridt tæller.");
+    } else {
+      toast("Nice job! Small steps add up.");
+    }
     renderSidebar(state, Lang, navigateTo);
   };
 }


### PR DESCRIPTION
## Summary
- Show a Danish or English motivational toast after marking a page complete.

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed6a6a480832a9407298b81d3f651