### PR TITLE
Add stress tracking slider with persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ const Lang = {
     progressTitle: "Your Progress",
     badgesTitle: "Badges",
     activityTitle: "Recent activity",
+    stressToday: "How stressed are you today?",
     none: "—",
 
     modulesData: [
@@ -123,6 +124,7 @@ const Lang = {
     progressTitle: "Dit fremskridt",
     badgesTitle: "Mærker",
     activityTitle: "Seneste aktivitet",
+    stressToday: "Hvor stresset føler du dig i dag?",
     none: "—",
 
     modulesData: [
@@ -181,7 +183,7 @@ let state = Store.load();
 function t(k){ return Lang[state.lang][k]; }
 function todayKey(){ return new Date().toISOString().slice(0,10); }
 function now(){ return new Date().toISOString(); }
-function toast(msg){ let d=document.createElement("div"); d.textContent=msg;
+export function toast(msg){ let d=document.createElement("div"); d.textContent=msg;
   d.style.cssText="position:fixed;bottom:16px;left:50%;transform:translateX(-50%);background:#0b1224;padding:10px 14px;border:1px solid #1f2937;border-radius:10px;color:#e5e7eb;z-index:9999";
   document.body.appendChild(d); setTimeout(function(){ d.remove(); },2000);
 }
@@ -263,7 +265,7 @@ function initTopbarMenu(){
 }
 
 /* Exercise locale strings */
-const EX={
+export const EX={
   en:{add:"Add",save:"Save",delete:"Delete",done:"Done",edit:"Edit",
       distressQ:"Rate your current diabetes distress (0 = none, 10 = max)", bodyQ:"Where do you feel it in your body?", noteQ:"Short note (optional)", viewTrend:"View personal trend", chartHint:"Your saved ratings will show here as a line chart.",
       trigger:"Trigger", typicalThought:"Typical thought", feelingWord:"Feeling (word + 0–10)", noTriggers:"No triggers logged yet.",

--- a/render.js
+++ b/render.js
@@ -1,4 +1,5 @@
-import { BADGES } from './app.js';
+import { BADGES, EX, toast } from './app.js';
+import { Store } from './storage.js';
 
 export function renderTexts(state, t) {
   document.getElementById("brandTitle").textContent = t("brandTitle");
@@ -68,10 +69,32 @@ export function renderHome(state, t, overallProgress) {
           + '<div class="progress-ring" style="--p:' + pctNum + '%"><b>' + pctNum + '%</b></div>'
           + '<div class="notice" style="flex:1;min-width:240px;">' + t("notEmergency") + '</div>'
         + '</div>'
+        + '<article class="flow"><label for="stressSlider">' + t("stressToday") + '</label><div class="row" style="align-items:center;gap:12px;"><input id="stressSlider" type="range" min="0" max="10" value="5"><span class="chip" id="stressVal">5</span><button class="primary" id="stressSave">' + t("save") + '</button></div></article>'
         + '<article class="flow"><h2>' + t("badgesTitle") + '</h2><div class="badgebar" id="badgeBar">' + badges + '</div></article>'
         + '<article class="flow"><h2>' + t("activityTitle") + '</h2><div class="timeline" id="timeline">' + recent + '</div></article>'
       + '</section>'
     + '</div>';
+
+  const sliderEl = document.getElementById("stressSlider");
+  const valChip = document.getElementById("stressVal");
+  const saveBtn = document.getElementById("stressSave");
+  if (sliderEl && valChip && saveBtn) {
+    sliderEl.oninput = () => {
+      valChip.textContent = sliderEl.value;
+    };
+    saveBtn.onclick = () => {
+      const rating = +sliderEl.value;
+      const id = 'm1p2';
+      if (!state.exercises) state.exercises = {};
+      if (!state.exercises[id]) state.exercises[id] = {};
+      if (!state.exercises[id].trend) state.exercises[id].trend = [];
+      state.exercises[id].trend.push({ d: new Date().toISOString().slice(0,10), v: rating });
+      if (!state.timeline) state.timeline = [];
+      state.timeline.push({ t: new Date().toISOString(), what: 'Distress ' + rating + '/10' });
+      Store.save(state);
+      toast(EX[state.lang].saved);
+    };
+  }
 }
 export function renderData(state, t) {
   const main = document.getElementById("main");


### PR DESCRIPTION
## Summary
- Add `stressToday` translation for English and Danish locales
- Render stress rating slider on home page with current value and save button
- Persist slider entries, update timeline, and show toast feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef1a6b7f0832a9086a4b42e656a40