### PR TITLE
Refactor streak heatmap styling to CSS classes

### DIFF
--- a/render.js
+++ b/render.js
@@ -61,14 +61,13 @@ export function renderHome(state, t, overallProgress) {
     days.push({ key, count: dayCounts[key] || 0 });
   }
   const max = days.reduce((m, d) => Math.max(m, d.count), 0) || 1;
-  const colors = ['#1f2937', '#9be9a8', '#40c463', '#30a14e', '#216e39'];
   const cells = days.map(d => {
-    const lvl = d.count ? Math.ceil((d.count / max) * (colors.length - 1)) : 0;
-    return '<span title="' + d.key + ': ' + d.count + '" style="width:4px;height:4px;border-radius:1px;background:' + colors[lvl] + '"></span>';
+    const lvl = d.count ? Math.ceil((d.count / max) * 4) : 0;
+    return '<span title="' + d.key + ': ' + d.count + '" class="streak-cell level-' + lvl + '"></span>';
   }).join('');
   const streakCount = (state.streak && state.streak.count) || 0;
   const lbl = (state.lang === 'da' ? 'Stime' : 'Streak') + ' ' + streakCount;
-  streakHtml = '<div id="streakText" title="' + lbl + '" aria-label="' + lbl + '"><span style="display:grid;grid-template-rows:repeat(7,4px);grid-auto-flow:column;gap:1px">' + cells + '</span></div>';
+  streakHtml = '<div id="streakText" title="' + lbl + '" aria-label="' + lbl + '"><span class="streak-grid">' + cells + '</span></div>';
 
   const unlocked = new Set(state.badges || []);
   const badges = BADGES.map(b => {

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@
   --bg:#0f172a; --panel:#0b1224; --muted:#94a3b8; --text:#e5e7eb;
   --primary:#22c55e; --primary-600:#16a34a; --accent:#38bdf8; --warn:#f59e0b; --danger:#ef4444;
   --card:#111827; --chip:#1f2937; --border:#1f2937; --shadow:0 0.625rem 1.875rem rgba(0,0,0,.35); --radius:0.875rem;
+  --streak-0:#1f2937; --streak-1:#9be9a8; --streak-2:#40c463; --streak-3:#30a14e; --streak-4:#216e39;
 }
 *{box-sizing:border-box}
 .sr-only{
@@ -67,6 +68,13 @@ button.ghost{background:transparent; border:1px dashed var(--border)} button:dis
 .badgebar{display:flex; gap:0.5rem; flex-wrap:wrap}
 .chip{background:var(--chip); border:1px solid var(--border); padding:0.375rem 0.625rem; border-radius:999px; font-size:.85rem}
 .chip.locked{opacity:0.4; filter:grayscale(1);}
+.streak-grid{display:grid;grid-template-rows:repeat(7,var(--streak-size,4px));grid-auto-flow:column;gap:1px}
+.streak-cell{width:var(--streak-size,4px);height:var(--streak-size,4px);border-radius:var(--streak-radius,1px);background:var(--streak-color,var(--streak-0))}
+.level-0{--streak-color:var(--streak-0)}
+.level-1{--streak-color:var(--streak-1)}
+.level-2{--streak-color:var(--streak-2)}
+.level-3{--streak-color:var(--streak-3)}
+.level-4{--streak-color:var(--streak-4)}
 .flow{display:grid; gap:0.875rem}
 .checklist label{display:flex; gap:0.625rem; align-items:flex-start; padding:0.5rem; border:1px solid var(--border); border-radius:0.625rem}
 input[type="checkbox"]{width:1.125rem;height:1.125rem}


### PR DESCRIPTION
## Summary
- Define reusable streak heatmap styles and color variables in `styles.css`
- Replace inline heatmap styles in `render.js` with semantic classes

## Testing
- `node --check render.js`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aef9d6a7b4832abfb7a7263ca96610