### PR TITLE
Limit stored history to last 30 entries

### DIFF
--- a/render.js
+++ b/render.js
@@ -1,5 +1,5 @@
 import { BADGES, EX, toast } from './app.js';
-import { Store } from './storage.js';
+import { Store, capArray } from './storage.js';
 
 export function renderTexts(state, t) {
   document.getElementById("brandTitle").textContent = t("brandTitle");
@@ -121,8 +121,10 @@ export function renderHome(state, t, overallProgress) {
       if (!state.exercises[id]) state.exercises[id] = {};
       if (!state.exercises[id].trend) state.exercises[id].trend = [];
       state.exercises[id].trend.push({ d: new Date().toISOString().slice(0,10), v: rating });
+      capArray(state.exercises[id].trend);
       if (!state.timeline) state.timeline = [];
       state.timeline.push({ t: new Date().toISOString(), what: 'Distress ' + rating + '/10' });
+      capArray(state.timeline);
       Store.save(state);
       toast(EX[state.lang].saved);
     };

--- a/storage.js
+++ b/storage.js
@@ -42,3 +42,10 @@ export const Store = {
     localStorage.setItem(this.key, JSON.stringify(clean));
   }
 };
+
+// Keep only the last `max` entries of an array (mutates the array in place)
+export function capArray(arr, max = 30) {
+  if (Array.isArray(arr) && arr.length > max) {
+    arr.splice(0, arr.length - max);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `capArray` helper to trim arrays to their last 30 entries
- Ensure distress timeline and per-exercise trends keep only recent 30 entries

## Testing
- `node --check render.js`
- `node --check app.js`
- `node -e "import('./storage.js').then(({capArray})=>{let state={timeline:[]};for(let i=0;i<35;i++){state.timeline.push({t:new Date(Date.now()-(34-i)*24*3600*1000).toISOString(),what:'x'+i});}capArray(state.timeline);const dayCounts={};state.timeline.forEach(ev=>{const key=ev.t.slice(0,10);dayCounts[key]=(dayCounts[key]||0)+1;});const days=[];const today=new Date();for(let i=29;i>=0;i--){const d=new Date(today);d.setDate(today.getDate()-i);const key=d.toISOString().slice(0,10);days.push(key);}console.log(state.timeline.length,Object.keys(dayCounts).length,days.length,days[0],days[29]);});"

------
https://chatgpt.com/codex/tasks/task_e_68aefc041f08832a856be87327c5a7cc