### PR TITLE
Add onboarded flag to storage validation

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -14,6 +14,7 @@ export const Store = {
     o.streak = d.streak && typeof d.streak.count === "number" ? { last: d.streak.last || null, count: d.streak.count } : { last: null, count: 0 };
     o.timeline = Array.isArray(d.timeline) ? d.timeline : [];
     o.badges = Array.isArray(d.badges) ? d.badges : [];
+    o.onboarded = typeof d.onboarded === "boolean" ? d.onboarded : false;
     return o;
   },
   migrate(d) {


### PR DESCRIPTION
## Summary
- track whether user has completed onboarding via new `onboarded` field

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/diabetes_distress/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aff1b924ec832abeadf16c0562d4af