### PR TITLE
Add intro overlay and slide navigation styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -159,3 +159,34 @@ footer{color:#8aa0be; font-size:.9rem; padding:1.125rem; border-top:1px solid va
 .mini-progress .bar{position:relative; flex:1; height:0.625rem; background:#0b1224; border:1px solid var(--border); border-radius:999px; overflow:hidden;}
 .mini-progress .bar > i{position:absolute; left:0; top:0; bottom:0; width:0%; background:linear-gradient(90deg, var(--primary), #34d399); transform-origin:left center;}
 .mini-progress .txt{font-size:.9rem; color:#cfe9d9; min-width:6.875rem; text-align:right}
+
+/* Intro overlay and modal */
+.intro-overlay{
+  position:fixed; inset:0;
+  background:rgba(0,0,0,.7);
+  display:flex; align-items:center; justify-content:center;
+  z-index:1000;
+}
+.intro-modal{
+  background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,0));
+  border:1px solid var(--border); border-radius:var(--radius);
+  padding:1.125rem; box-shadow:var(--shadow);
+  max-width:25rem; width:100%;
+}
+.intro-slide{display:none}
+.intro-slide.active{display:block}
+.intro-nav{display:flex; justify-content:center; gap:0.5rem; margin-top:1rem}
+.intro-nav button{
+  width:0.625rem; height:0.625rem;
+  border-radius:50%; border:none; cursor:pointer;
+  background:#e5e7eb; opacity:0.4;
+}
+.intro-nav button.active{opacity:1}
+.intro-arrow{
+  position:absolute; top:50%; transform:translateY(-50%);
+  width:2rem; height:2rem; border-radius:50%;
+  border:none; display:flex; align-items:center; justify-content:center;
+  background:rgba(0,0,0,.5); color:#e5e7eb; cursor:pointer;
+}
+.intro-arrow.prev{left:0.5rem}
+.intro-arrow.next{right:0.5rem}


### PR DESCRIPTION
## Summary
- add `.intro-overlay` and `.intro-modal` for centered intro card with backdrop overlay
- provide `.intro-slide` with navigation dots and arrows for basic slide control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b00eeccaa4832ab33ea1493b9dd099