### PR TITLE
Add light mode theme toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ const Lang = {
     none: "—",
     noStreakData: "No streak data",
     journal: "Journal",
+    theme: "Theme",
     journalEmpty: "No notes yet.",
     onboardSlides: [
       "Work module by module",
@@ -135,6 +136,7 @@ const Lang = {
     none: "—",
     noStreakData: "Ingen stime-data",
     journal: "Journal",
+    theme: "Tema",
     journalEmpty: "Ingen noter endnu.",
     onboardSlides: [
       "Arbejd modul for modul",
@@ -882,6 +884,13 @@ function showOnboarding() {
 function init() {
   initDrawer();
   initTopbarMenu();
+  if (state.theme === "light") document.body.classList.add("light");
+  const themeBtn = document.getElementById("themeToggle");
+  if (themeBtn) themeBtn.onclick = () => {
+    state.theme = state.theme === "light" ? "dark" : "light";
+    document.body.classList.toggle("light", state.theme === "light");
+    Store.save(state);
+  };
   document.getElementById("langSelect").onchange = e => {
     state.lang = e.target.value;
     Store.save(state);

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <button class="ghost" id="homeBtn" aria-label="Forside"><span class="sr-only">Forside</span>🏠</button>
       <button class="ghost" id="dataBtn" aria-label="Data"><span class="sr-only">Data</span>💾</button>
       <button class="ghost" id="journalBtn" aria-label="Journal"><span class="sr-only">Journal</span>📝</button>
+      <button class="ghost" id="themeToggle" aria-label="Tema"><span class="sr-only">Tema</span>🌓</button>
       <select id="langSelect" class="ghost">
         <option value="da">Dansk</option>
         <option value="en">English</option>

--- a/render.js
+++ b/render.js
@@ -22,6 +22,12 @@ export function renderTexts(state, t) {
     const srJ = journalBtn.querySelector(".sr-only");
     if (srJ) srJ.textContent = t("journal");
   }
+  const themeBtn = document.getElementById("themeToggle");
+  if (themeBtn) {
+    themeBtn.setAttribute("aria-label", t("theme"));
+    const srT = themeBtn.querySelector(".sr-only");
+    if (srT) srT.textContent = t("theme");
+  }
   document.getElementById("langSelect").value = state.lang;
 }
 

--- a/storage.js
+++ b/storage.js
@@ -9,6 +9,7 @@ export const Store = {
     const o = {};
     o.version = typeof d.version === "number" ? d.version : this.version;
     o.lang = typeof d.lang === "string" ? d.lang : "da";
+    o.theme = d.theme === "light" ? "light" : "dark";
     o.completed = d.completed && typeof d.completed === "object" ? d.completed : {};
     o.exercises = d.exercises && typeof d.exercises === "object" ? d.exercises : {};
     o.streak = d.streak && typeof d.streak.count === "number" ? { last: d.streak.last || null, count: d.streak.count } : { last: null, count: 0 };

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,13 @@
   --card:#111827; --chip:#1f2937; --border:#1f2937; --shadow:0 0.625rem 1.875rem rgba(0,0,0,.35); --radius:0.875rem;
   --streak-0:#1f2937; --streak-1:#9be9a8; --streak-2:#40c463; --streak-3:#30a14e; --streak-4:#216e39;
 }
+
+:root.light{
+  --bg:#f8fafc; --panel:#ffffff; --muted:#475569; --text:#0f172a;
+  --primary:#22c55e; --primary-600:#16a34a; --accent:#0ea5e9; --warn:#d97706; --danger:#dc2626;
+  --card:#ffffff; --chip:#e2e8f0; --border:#cbd5e1; --shadow:0 0.625rem 1.875rem rgba(0,0,0,.15); --radius:0.875rem;
+  --streak-0:#e2e8f0; --streak-1:#bbf7d0; --streak-2:#86efac; --streak-3:#4ade80; --streak-4:#22c55e;
+}
 *{box-sizing:border-box}
 .sr-only{
   position:absolute;


### PR DESCRIPTION
## Summary
- introduce configurable light theme CSS variables
- add theme toggle button in header with localized label
- persist selected theme and toggle body class

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04de04f14832a8efc6f62263553f8