### PR TITLE
Use root element for theme toggling

### DIFF
--- a/app.js
+++ b/app.js
@@ -884,11 +884,11 @@ function showOnboarding() {
 function init() {
   initDrawer();
   initTopbarMenu();
-  if (state.theme === "light") document.body.classList.add("light");
+  if (state.theme === "light") document.documentElement.classList.add("light");
   const themeBtn = document.getElementById("themeToggle");
   if (themeBtn) themeBtn.onclick = () => {
     state.theme = state.theme === "light" ? "dark" : "light";
-    document.body.classList.toggle("light", state.theme === "light");
+    document.documentElement.classList.toggle("light", state.theme === "light");
     Store.save(state);
   };
   document.getElementById("langSelect").onchange = e => {


### PR DESCRIPTION
## Summary
- Apply light theme class to `document.documentElement`
- Toggle root element class when switching themes

## Testing
- `node - <<'NODE'` (simulates toggle and confirms root class and `--bg` variable change)


------
https://chatgpt.com/codex/tasks/task_e_68b052a571e0832a834b3eef87ba395f