### PR TITLE
Add module icons to sidebar

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,47 +54,47 @@ const Lang = {
     gotIt: "Got it",
 
     modulesData: [
-      { id:"m1", title:"1) Orientation", goal:"Get comfortable with how the program works.", pages:[
+      { id:"m1", title:"1) Orientation", icon:"📘", goal:"Get comfortable with how the program works.", pages:[
         {id:"m1p1",type:"read",title:"What is Diabetes Distress?",
          body:"<p>Diabetes distress is the emotional burden of living with diabetes—frustration, guilt, fear, or burnout. It’s common and <em>treatable</em>.</p>"},
         {id:"m1p2",type:"exercise",exercise:"distress-rating",title:"Baseline Distress"},
         {id:"m1p3",type:"read",title:"How to Use This App",
          body:"<ol><li>Work module by module (about 10–20 mins each).</li><li>Do the exercises — they’re where change happens.</li><li>Revisit tools anytime. Small steps compound.</li></ol>"},
       ]},
-      { id:"m2", title:"2) Understanding Triggers", goal:"Spot patterns: people, places, numbers that spark distress.", pages:[
+      { id:"m2", title:"2) Understanding Triggers", icon:"🎯", goal:"Spot patterns: people, places, numbers that spark distress.", pages:[
         {id:"m2p1",type:"read",title:"Common Triggers",
          body:"<p>Examples include: glucose readings, mealtime timing, judgment from others, clinic appointments, or fear of complications.</p>"},
         {id:"m2p2",type:"exercise",exercise:"trigger-log",title:"Trigger Log"},
         {id:"m2p3",type:"read",title:"Self-Compassion",
          body:"<p>A kind voice helps motivation more than self-criticism. Try speaking to yourself as you would to a friend.</p>"},
       ]},
-      { id:"m3", title:"3) Thoughts & Feelings", goal:"Map thoughts → feelings → actions. Learn reframing.", pages:[
+      { id:"m3", title:"3) Thoughts & Feelings", icon:"💭", goal:"Map thoughts → feelings → actions. Learn reframing.", pages:[
         {id:"m3p1",type:"read",title:"CBT Map",
          body:"<p>Event → Thought → Feeling → Action. We can’t always change events, but we can test and adjust thoughts.</p>"},
         {id:"m3p2",type:"exercise",exercise:"thought-record",title:"Thought Record"},
         {id:"m3p3",type:"exercise",exercise:"reframe-dnd",title:"Cognitive Reframe (Drag & Drop)"},
       ]},
-      { id:"m4", title:"4) Problem Solving", goal:"Move from stuck to steps.", pages:[
+      { id:"m4", title:"4) Problem Solving", icon:"🛠️", goal:"Move from stuck to steps.", pages:[
         {id:"m4p1",type:"read",title:"5-Step Problem Solver",
          body:"<ol><li>Define the problem.</li><li>Brainstorm options.</li><li>Pick 1–2 realistic steps.</li><li>Plan details (when/where/how).</li><li>Review & adjust.</li></ol>"},
         {id:"m4p2",type:"exercise",exercise:"problem-solver",title:"Your Plan"},
         {id:"m4p3",type:"exercise",exercise:"activity-planner",title:"Small Action Planner"},
       ]},
-      { id:"m5", title:"5) Values & Motivation", goal:"Anchor actions in what matters to you.", pages:[
+      { id:"m5", title:"5) Values & Motivation", icon:"🌟", goal:"Anchor actions in what matters to you.", pages:[
         {id:"m5p1",type:"read",title:"Values vs. Goals",
          body:"<p>Values guide direction (ongoing), goals are steps (done/undone). When actions align with values, motivation sustains.</p>"},
         {id:"m5p2",type:"exercise",exercise:"values-sort",title:"Values Sort"},
       ]},
-      { id:"m6", title:"6) Coping Skills", goal:"Regulate physiology and plan supports.", pages:[
+      { id:"m6", title:"6) Coping Skills", icon:"🧘", goal:"Regulate physiology and plan supports.", pages:[
         {id:"m6p1",type:"exercise",exercise:"breathing",title:"Guided Breathing"},
         {id:"m6p2",type:"exercise",exercise:"coping-plan",title:"Coping Plan"},
       ]},
-      { id:"m7", title:"7) Communicating with Care", goal:"Ask for what you need with clarity & kindness.", pages:[
+      { id:"m7", title:"7) Communicating with Care", icon:"💬", goal:"Ask for what you need with clarity & kindness.", pages:[
         {id:"m7p1",type:"read",title:"Assertive Script",
          body:"<p>Use <strong>COPE</strong>: <em>Context</em>, <em>Observation</em>, <em>Preference</em>, <em>Enlist</em>.</p>"},
         {id:"m7p2",type:"exercise",exercise:"care-script",title:"Build Your Script"},
       ]},
-      { id:"m8", title:"8) Maintenance", goal:"Keep gains, handle setbacks.", pages:[
+      { id:"m8", title:"8) Maintenance", icon:"🔄", goal:"Keep gains, handle setbacks.", pages:[
         {id:"m8p1",type:"exercise",exercise:"relapse-plan",title:"Relapse Prevention"},
         {id:"m8p2",type:"read",title:"Next Steps",
          body:"<p>Revisit modules; track distress weekly; celebrate wins. Consider discussing insights with your care team.</p>"},
@@ -146,47 +146,47 @@ const Lang = {
     gotIt: "Forstået",
 
     modulesData: [
-      { id:"m1", title:"1) Introduktion", goal:"Bliv fortrolig med, hvordan programmet fungerer.", pages:[
+      { id:"m1", title:"1) Introduktion", icon:"📘", goal:"Bliv fortrolig med, hvordan programmet fungerer.", pages:[
         {id:"m1p1",type:"read",title:"Hvad er diabetes-stress?",
          body:"<p>Diabetes-stress er den følelsesmæssige byrde ved at leve med diabetes — frustration, skyld, frygt eller udbrændthed. Det er almindeligt og <em>kan behandles</em>.</p>"},
         {id:"m1p2",type:"exercise",exercise:"distress-rating",title:"Grundlinje for stress"},
         {id:"m1p3",type:"read",title:"Sådan bruges appen",
          body:"<ol><li>Arbejd modul for modul (ca. 10–20 min. hver).</li><li>Lav øvelserne — det er dér forandring sker.</li><li>Genbesøg værktøjerne når som helst. Små skridt giver store resultater.</li></ol>"},
       ]},
-      { id:"m2", title:"2) Forstå triggere", goal:"Se mønstre: personer, steder, tal der udløser stress.", pages:[
+      { id:"m2", title:"2) Forstå triggere", icon:"🎯", goal:"Se mønstre: personer, steder, tal der udløser stress.", pages:[
         {id:"m2p1",type:"read",title:"Almindelige triggere",
          body:"<p>Eksempler: blodsukkermålinger, måltider, andres vurderinger, klinikbesøg eller frygt for komplikationer.</p>"},
         {id:"m2p2",type:"exercise",exercise:"trigger-log",title:"Trigger-logbog"},
         {id:"m2p3",type:"read",title:"Selvmedfølelse",
          body:"<p>En venlig stemme støtter motivation bedre end selvkritik. Prøv at tale til dig selv, som du ville til en ven.</p>"},
       ]},
-      { id:"m3", title:"3) Tanker & Følelser", goal:"Kortlæg tanker → følelser → handlinger. Lær at omformulere.", pages:[
+      { id:"m3", title:"3) Tanker & Følelser", icon:"💭", goal:"Kortlæg tanker → følelser → handlinger. Lær at omformulere.", pages:[
         {id:"m3p1",type:"read",title:"KAT-kort",
          body:"<p>Hændelse → Tanke → Følelse → Handling. Vi kan ikke altid ændre hændelser, men vi kan teste og justere tanker.</p>"},
         {id:"m3p2",type:"exercise",exercise:"thought-record",title:"Tankeskema"},
         {id:"m3p3",type:"exercise",exercise:"reframe-dnd",title:"Kognitiv omformulering (træk & slip)"},
       ]},
-      { id:"m4", title:"4) Problemløsning", goal:"Fra fastlåst til handleplan.", pages:[
+      { id:"m4", title:"4) Problemløsning", icon:"🛠️", goal:"Fra fastlåst til handleplan.", pages:[
         {id:"m4p1",type:"read",title:"5-trins problemløser",
          body:"<ol><li>Definér problemet.</li><li>Brainstorm muligheder.</li><li>Vælg 1–2 realistiske skridt.</li><li>Planlæg detaljer (hvornår/hvor/hvordan).</li><li>Evaluer & justér.</li></ol>"},
         {id:"m4p2",type:"exercise",exercise:"problem-solver",title:"Din plan"},
         {id:"m4p3",type:"exercise",exercise:"activity-planner",title:"Lille handlingsplan"},
       ]},
-      { id:"m5", title:"5) Værdier & Motivation", goal:"Forankr handlinger i det, der betyder mest for dig.", pages:[
+      { id:"m5", title:"5) Værdier & Motivation", icon:"🌟", goal:"Forankr handlinger i det, der betyder mest for dig.", pages:[
         {id:"m5p1",type:"read",title:"Værdier vs. mål",
          body:"<p>Værdier giver retning (løbende), mål er konkrete skridt (gennemført/ikke gennemført). Når handlinger stemmer overens med værdier, holder motivationen længere.</p>"},
         {id:"m5p2",type:"exercise",exercise:"values-sort",title:"Værdiafklaring"},
       ]},
-      { id:"m6", title:"6) Mestringsstrategier", goal:"Regulér kroppen og planlæg støtte.", pages:[
+      { id:"m6", title:"6) Mestringsstrategier", icon:"🧘", goal:"Regulér kroppen og planlæg støtte.", pages:[
         {id:"m6p1",type:"exercise",exercise:"breathing",title:"Vejrtrækningsøvelse"},
         {id:"m6p2",type:"exercise",exercise:"coping-plan",title:"Mestringsplan"},
       ]},
-      { id:"m7", title:"7) Kommunikation med omsorg", goal:"Bed om det du har brug for, klart og venligt.", pages:[
+      { id:"m7", title:"7) Kommunikation med omsorg", icon:"💬", goal:"Bed om det du har brug for, klart og venligt.", pages:[
         {id:"m7p1",type:"read",title:"Assertiv kommunikation",
          body:"<p>Brug <strong>COPE</strong>: <em>Kontekst</em>, <em>Observation</em>, <em>Præference</em>, <em>Engagér</em>.</p>"},
         {id:"m7p2",type:"exercise",exercise:"care-script",title:"Byg dit manuskript"},
       ]},
-      { id:"m8", title:"8) Vedligeholdelse", goal:"Bevar fremskridt og håndtér tilbagefald.", pages:[
+      { id:"m8", title:"8) Vedligeholdelse", icon:"🔄", goal:"Bevar fremskridt og håndtér tilbagefald.", pages:[
         {id:"m8p1",type:"exercise",exercise:"relapse-plan",title:"Tilbagefaldsplan"},
         {id:"m8p2",type:"read",title:"Næste skridt",
          body:"<p>Genbesøg modulerne; følg din stress ugentligt; fejre sejre. Overvej at drøfte dine indsigter med dit behandlingsteam.</p>"},

--- a/render.js
+++ b/render.js
@@ -39,7 +39,8 @@ export function renderSidebar(state, Lang, navigateTo) {
     const pct = Math.round((done / m.pages.length) * 100);
     const div = document.createElement("div");
     div.className = "mod";
-    div.innerHTML = '<div><div class="t">' + m.title + '</div><div class="tiny">' + m.goal + '</div><div class="progressbar"><i style="width:' + pct + '%"></i></div></div><div class="badge">' + pct + '%</div>';
+    const icon = m.icon ? m.icon + ' ' : '';
+    div.innerHTML = '<div><div class="t">' + icon + m.title + '</div><div class="tiny">' + m.goal + '</div><div class="progressbar"><i style="width:' + pct + '%"></i></div></div><div class="badge">' + pct + '%</div>';
     div.onclick = () => navigateTo(mi, 0);
     list.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- add icon property for each module in both languages
- display module icons in sidebar for improved readability

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a4c31554832aa9fcfd32471d642d